### PR TITLE
ci: add Python version matrix to PR workflow

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -1,11 +1,9 @@
 # This workflow will install Python dependencies, run tests and lint with a single version of Python
 # For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-python
 
-name: Python application
+name: Pull request checks
 
 on:
-  push:
-    branches: [ "main" ]
   pull_request:
     branches: [ "main" ]
 
@@ -16,13 +14,19 @@ jobs:
   tests:
 
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        # 3.14 has a build issue related to the resolved Py03 version.
+        # Py03 itself supports 3.14, 3.14t since 0.26.0: https://github.com/PyO3/pyo3/releases/tag/v0.26.0
+        # python-version: [3.13, 3.14.0-rc.3]
+        python-version: [3.13]
 
     steps:
     - uses: actions/checkout@v5
-    - name: Set up Python 3.13
+    - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v6
       with:
-        python-version: "3.13"
+        python-version: ${{ matrix.python-version }}
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pipenv wheel    

--- a/.gitignore
+++ b/.gitignore
@@ -133,5 +133,8 @@ dmypy.json
 # Presently ignoring, as only contains a non-portable path
 .vscode/
 
+# Coding assistants
+.claude/*.local.json
+
 # program-specific data files
 /data/

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ For all methods, you must first check out or download the code.
 
 For the script to run, you will need to setup an environment with the dependencies. The current recommended method is using `pipenv`, which helps manage the details of the virtual envionment, and provides deterministic builds via a lockfile (while requiring a specific python version):
 
-1. Make sure you have both `python` (3.10) as well as `pip` installed on your system
+1. Make sure you have both `python` (3.13) as well as `pip` installed on your system
 2. Run `pip install pipenv --user`
 
 See the `pipenv` [docs for details](https://pipenv.pypa.io/en/latest/installation/#pipenv-installation)


### PR DESCRIPTION
Allow running the tests against multiple python versions.

While it was planned to be added, for now, we don't run against 3.14, as it isn't supported by all dependencies just yet:

<img width="607" height="401" alt="Screenshot 2025-09-26 at 16 40 54" src="https://github.com/user-attachments/assets/8dd39751-4060-4799-9b52-fd929bb784ae" />
